### PR TITLE
Allow latest SymPy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.19.2 # for numerical calculations
 sphinx>=3.3.1  # generating documentation
 sphinx_rtd_theme>=0.4.3  # docs theme
-sympy>=1.4,<1.8  # for analytical integration
+sympy>=1.4  # for analytical integration
 sphinxcontrib-bibtex ##for sphinx bib importing
 plotly>=4.14.1
 #kaleido # for saving figures, removed to make loading in google colab faster

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
   install_requires=[            
           'matplotlib',
           'numpy',
-          'sympy>=1.4,<1.8',
+          'sympy>=1.4',
           'plotly>=4.14.1',
       ],
   classifiers=[


### PR DESCRIPTION
Currently, installing IndeterminateBeam downgrades the version of SymPy installed. The tests run fine with the latest SymPy 1.9. I also updated `requirements.txt` so that Travis CI tests with the latest version.