### PR TITLE
fix: use supported arrows for point torques

### DIFF
--- a/indeterminatebeam/plotly_drawing_aid.py
+++ b/indeterminatebeam/plotly_drawing_aid.py
@@ -428,11 +428,13 @@ def draw_moment(
         Returns the plotly figure passed into function with the circular
         arrow appended to it.
     """
-    # Choose symbol based on direction given
+    # Choose symbol based on direction given. Use the more widely supported
+    # U+21BA/U+21BB arrows rather than U+2B6E/U+2B6F, which can render as
+    # missing-glyph squares in browsers/environments without Noto Symbols 2.
     if moment < 0:
-        d = "⭮"
+        d = "↻"
     elif moment > 0:
-        d = "⭯"
+        d = "↺"
     else:
         return fig
 
@@ -442,7 +444,7 @@ def draw_moment(
         text=d,
         showarrow=False,
         yshift=0,
-        font_size=26,
+        font_size=28,
         font_color=color,
     )
 

--- a/tests/test_indeterminatebeam.py
+++ b/tests/test_indeterminatebeam.py
@@ -159,6 +159,19 @@ class BeamTestCase(unittest.TestCase):
         fig = beam.plot_beam_external()
         fig = beam.plot_beam_internal()
 
+        torque_beam = Beam(5)
+        torque_beam.add_supports(Support(0, (1, 1, 1)), Support(5, (1, 1, 1)))
+        torque_beam.add_loads(PointTorque(10, 2.5))
+        fig = torque_beam.plot_beam_external()
+        annotation_text = [annotation.text for annotation in fig.layout.annotations]
+        self.assertIn("↺", annotation_text)
+
+        torque_beam.remove_loads(remove_all=True)
+        torque_beam.add_loads(PointTorque(-10, 2.5))
+        fig = torque_beam.plot_beam_external()
+        annotation_text = [annotation.text for annotation in fig.layout.annotations]
+        self.assertIn("↻", annotation_text)
+
         fig = beam.plot_beam_diagram()
         fig = beam.plot_reaction_force()
 


### PR DESCRIPTION
## Summary
- Replace point torque annotation glyphs with more widely supported circular arrows (`↺` / `↻`)
- Increase the torque arrow annotation font size from 26 to 28 after visual review
- Add regression coverage for positive and negative point torque annotations

## Test plan
- `python3 -m pytest tests/test_indeterminatebeam.py tests/test_distributed_load_total.py -q`
- Result: `25 passed in 5.13s`

Closes #40